### PR TITLE
chore: remove token provider

### DIFF
--- a/packages/fluttercon_api/lib/src/fluttercon_api.dart
+++ b/packages/fluttercon_api/lib/src/fluttercon_api.dart
@@ -6,9 +6,6 @@ import 'package:fluttercon_api/fluttercon_api.dart';
 import 'package:fluttercon_shared_models/fluttercon_shared_models.dart';
 import 'package:http/http.dart';
 
-/// Signature for the authentication token provider.
-typedef TokenProvider = Future<String?> Function();
-
 /// Generic type representing a JSON factory.
 typedef FromJson<T> = T Function(Map<String, dynamic> json);
 


### PR DESCRIPTION
## Description

- `TokenProvider` typedef was cruft from an earlier setup of the api. It is no longer needed. 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ X] 🗑️ Chore
