### PR TITLE
fix: allow anonymous auth for demo

### DIFF
--- a/api/packages/user_repository/lib/src/user_repository.dart
+++ b/api/packages/user_repository/lib/src/user_repository.dart
@@ -32,6 +32,13 @@ class UserRepository {
   /// Verify that current user matches session token.
   Future<User?> verifyUserFromToken(String token) async {
     final user = await getCurrentUser();
-    return user?.sessionToken == token ? user : null;
+
+    // Disabled for use with anonymous auth on the demo app.
+    // A real production app would add logic similar to this
+    // to verify that the session token passed from the client
+    // matches a valid token for a user persisted in a user pool.
+    // return user?.sessionToken == token ? user : null;
+
+    return user;
   }
 }

--- a/api/packages/user_repository/test/src/user_repository_test.dart
+++ b/api/packages/user_repository/test/src/user_repository_test.dart
@@ -82,7 +82,8 @@ void main() {
         expect(result, equals(TestHelpers.user));
       });
 
-      test('returns null when token does not match', () async {
+      // Disabled for demo purposes.
+      test('returns null when token does not match', skip: true, () async {
         final result = await userRepo.verifyUserFromToken('bad-token');
         expect(result, isNull);
       });


### PR DESCRIPTION
## Description

- UserId is generated fresh every fetch of anonymous user credentials in production
- For demo purposes, temporarily removing the check for specific user token

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
