### PR TITLE
fix: talk card width

### DIFF
--- a/lib/talks/view/talks_page.dart
+++ b/lib/talks/view/talks_page.dart
@@ -47,82 +47,80 @@ class TalksSchedule extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 800),
-      child: ListView.builder(
-        itemCount: talkTimeSlots.length,
-        itemBuilder: (context, index) {
-          final timeSlot = talkTimeSlots[index];
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Flexible(
-                child: Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: Text(
-                    DateFormat('MMM dd hh:mm:a')
-                        .format(timeSlot.startTime.toLocal()),
-                  ),
+    return ListView.builder(
+      itemCount: talkTimeSlots.length,
+      itemBuilder: (context, index) {
+        final timeSlot = talkTimeSlots[index];
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Flexible(
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(
+                  DateFormat('MMM dd hh:mm:a')
+                      .format(timeSlot.startTime.toLocal()),
                 ),
               ),
-              Flexible(
-                flex: 2,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: timeSlot.talks
-                      .map(
-                        (talk) => Card(
-                          child: Padding(
-                            padding: const EdgeInsets.all(8),
-                            child: Column(
-                              children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Flexible(flex: 4, child: Text(talk.title)),
-                                    Flexible(
-                                      child: IconButton(
-                                        onPressed: () {},
-                                        icon: const Icon(Icons.favorite_border),
-                                      ),
+            ),
+            Flexible(
+              flex: 2,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: timeSlot.talks
+                    .map(
+                      (talk) => Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: Column(
+                            children: [
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Flexible(flex: 4, child: Text(talk.title)),
+                                  Flexible(
+                                    child: IconButton(
+                                      onPressed: () {},
+                                      icon: const Icon(Icons.favorite_border),
                                     ),
-                                  ],
-                                ),
-                                const SizedBox(height: 16),
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        talk.speakerNames.join(', '),
-                                      ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 16),
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      talk.speakerNames.join(', '),
                                     ),
-                                  ],
-                                ),
-                                const SizedBox(height: 16),
-                                Row(
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        talk.room,
-                                      ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 16),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      talk.room,
                                     ),
-                                  ],
-                                ),
-                              ],
-                            ),
+                                  ),
+                                ],
+                              ),
+                            ],
                           ),
                         ),
-                      )
-                      .toList(),
-                ),
+                      ),
+                    )
+                    .toList(),
               ),
-            ],
-          );
-        },
-      ),
+            ),
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION

## Description

- Still not doing much UI work now, but wanted to make the cards take up as much space as they can on desktop view so it looks slightly less ugly

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
